### PR TITLE
feat: include city aliases in lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Deterministic, **exact-match** lookup that returns **plug types, voltage, and fr
 ## What’s inside
 
 - **/api/lookup** — Edge resolver (NFKD normalize → strip diacritics → lowercase → remove punctuation except spaces/hyphens → collapse spaces → trim → exact match in `merged.json`)
-- **/api/suggest** — Optional **prefix-only** suggestions from country names (still exact tokens)
-- **Dataset** — `merged.json` containing country codes, plug types, voltage, and frequency
+- **/api/suggest** — Optional **prefix-only** suggestions from country and city names (still exact tokens)
+- **Dataset** — `merged.json` containing country codes, plug specs, and major city aliases (with ASCII variants)
 - **UI** — Minimal search + result card with animations and P3 Pro CTA
 
 ## Run locally (Cursor or terminal)

--- a/app/api/lookup/route.ts
+++ b/app/api/lookup/route.ts
@@ -18,6 +18,8 @@ type Entry = {
   plug_type: string[]
   voltage: string[]
   frequency: string[]
+  cities?: string[]
+  asciiname?: string[]
 }
 
 const data = merged as Entry[]
@@ -25,6 +27,12 @@ const lookup = new Map<string, Entry>()
 for (const row of data) {
   lookup.set(norm(row.country), row)
   lookup.set(norm(row.code), row)
+  for (const city of row.cities ?? []) {
+    lookup.set(norm(city), row)
+  }
+  for (const city of row.asciiname ?? []) {
+    lookup.set(norm(city), row)
+  }
 }
 
 export async function GET(req: NextRequest) {

--- a/app/api/suggest/route.ts
+++ b/app/api/suggest/route.ts
@@ -11,12 +11,25 @@ function json(data: unknown, init?: ResponseInit) {
   return res
 }
 
-type Entry = { country: string }
+type Entry = {
+  country: string
+  cities?: string[]
+  asciiname?: string[]
+}
 const data = merged as Entry[]
-const entries = data.map(row => ({
-  key: norm(row.country),
-  name: row.country,
-}))
+const entriesMap = new Map<string, string>()
+for (const row of data) {
+  entriesMap.set(norm(row.country), row.country)
+  for (const city of row.cities ?? []) {
+    const key = norm(city)
+    if (!entriesMap.has(key)) entriesMap.set(key, city)
+  }
+  for (const city of row.asciiname ?? []) {
+    const key = norm(city)
+    if (!entriesMap.has(key)) entriesMap.set(key, city)
+  }
+}
+const entries = Array.from(entriesMap, ([key, name]) => ({ key, name }))
 
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get('q') ?? ''

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
       <SearchBar onSubmit={onSubmit} />
 
       <p className="mt-3 text-sm text-neutral-600">
-        Type a <em>country</em> or common alias (e.g., <span className="italic">UK</span>, <span className="italic">Holland</span>).
+        Type a <em>country</em>, <em>city</em>, or common alias (e.g., <span className="italic">UK</span>, <span className="italic">Holland</span>).
       </p>
 
       <div className="mt-8 w-full" aria-live="polite">


### PR DESCRIPTION
## Summary
- expand suggestion dataset to index city names
- allow resolver to map city aliases to their country
- document city alias support in UI and README

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689ab83d267c832fa7f47ec9bd74408a