### PR TITLE
Display city name before country in results

### DIFF
--- a/app/api/lookup/route.ts
+++ b/app/api/lookup/route.ts
@@ -49,6 +49,23 @@ export async function GET(req: NextRequest) {
     return json(body)
   }
 
+  let city: string | undefined
+  if (norm(entry.country) !== key && norm(entry.code) !== key) {
+    const cityIdx = entry.cities?.findIndex(c => norm(c) === key)
+    if (cityIdx !== undefined && cityIdx >= 0 && entry.cities) {
+      city = entry.cities[cityIdx]
+    } else {
+      const asciiIdx = entry.asciiname?.findIndex(c => norm(c) === key)
+      if (asciiIdx !== undefined && asciiIdx >= 0) {
+        if (entry.cities && entry.cities[asciiIdx]) {
+          city = entry.cities[asciiIdx]
+        } else if (entry.asciiname) {
+          city = entry.asciiname[asciiIdx]
+        }
+      }
+    }
+  }
+
   const spec = {
     plugTypes: entry.plug_type,
     voltage: entry.voltage.map(v => Number(v)),
@@ -58,7 +75,7 @@ export async function GET(req: NextRequest) {
   const version = process.env.DATASET_VERSION || 'DATASET_SAMPLE_2025_08_10'
   const body: LookupOk = {
     query: q,
-    resolved: { type: 'country', countryCode: entry.code, name: entry.country },
+    resolved: { type: 'country', countryCode: entry.code, name: entry.country, city },
     spec,
     confidence: 1.0,
     version,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import { SearchBar } from '@/components/SearchBar'
 
 type LookupOk = {
   query: string
-  resolved: { type: 'country'; countryCode: string; name?: string; flag?: string }
+  resolved: { type: 'country'; countryCode: string; name?: string; flag?: string; city?: string }
   spec: {
     plugTypes: string[]
     voltage: [number, number] | [number, number, number] | number[]

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -6,7 +6,7 @@ import { flagEmoji } from '@/lib/flags'
 
 export function ResultCard({ data }: { data: {
   query: string
-  resolved: { type: 'country'; countryCode: string; name?: string; flag?: string }
+  resolved: { type: 'country'; countryCode: string; name?: string; flag?: string; city?: string }
   spec: { plugTypes: string[]; voltage: number[]; frequencyHz: number; notes?: string; lastVerified?: string; sources?: string[] }
   confidence: number
   version: string
@@ -17,10 +17,13 @@ export function ResultCard({ data }: { data: {
   return (
     <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex items-center gap-2 text-lg font-semibold">
-          <span className="text-2xl">{flagEmoji(resolved.countryCode)}</span>
-          <span>{resolved.name ?? resolved.countryCode}</span>
-        </div>
+      <div className="flex items-center gap-2 text-lg font-semibold">
+        <span className="text-2xl">{flagEmoji(resolved.countryCode)}</span>
+        <span>
+          {resolved.city ? `${resolved.city}, ` : ''}
+          {resolved.name ?? resolved.countryCode}
+        </span>
+      </div>
         <span className="text-xs text-neutral-500 sm:text-right">Source: International Electrotechnical Commission</span>
       </div>
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -9,7 +9,7 @@ export type PlugSpec = {
   
   export type LookupOk = {
     query: string
-    resolved: { type: 'country'; countryCode: string; name?: string; flag?: string }
+    resolved: { type: 'country'; countryCode: string; name?: string; flag?: string; city?: string }
     spec: PlugSpec
     confidence: number
     version: string


### PR DESCRIPTION
## Summary
- Include matched city in lookup API responses
- Update result card UI to show "City, Country" when a city is queried
- Extend Lookup types to support optional city information

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689d3935fbd8832fa144722db393e6a4