### PR TITLE
Display country for city suggestions

### DIFF
--- a/app/api/suggest/route.ts
+++ b/app/api/suggest/route.ts
@@ -16,20 +16,26 @@ type Entry = {
   cities?: string[]
   asciiname?: string[]
 }
+
+type Suggestion = {
+  name: string
+  country?: string
+}
+
 const data = merged as Entry[]
-const entriesMap = new Map<string, string>()
+const entriesMap = new Map<string, Suggestion>()
 for (const row of data) {
-  entriesMap.set(norm(row.country), row.country)
+  entriesMap.set(norm(row.country), { name: row.country })
   for (const city of row.cities ?? []) {
     const key = norm(city)
-    if (!entriesMap.has(key)) entriesMap.set(key, city)
+    if (!entriesMap.has(key)) entriesMap.set(key, { name: city, country: row.country })
   }
   for (const city of row.asciiname ?? []) {
     const key = norm(city)
-    if (!entriesMap.has(key)) entriesMap.set(key, city)
+    if (!entriesMap.has(key)) entriesMap.set(key, { name: city, country: row.country })
   }
 }
-const entries = Array.from(entriesMap, ([key, name]) => ({ key, name }))
+const entries = Array.from(entriesMap, ([key, s]) => ({ key, ...s }))
 
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get('q') ?? ''
@@ -40,6 +46,6 @@ export async function GET(req: NextRequest) {
   const suggestions = entries
     .filter(e => e.key.startsWith(key))
     .slice(0, 10)
-    .map(e => e.name)
+    .map(({ name, country }) => ({ name, country }))
   return json({ suggestions })
 }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -4,10 +4,15 @@ import { useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowRight, Check, Spinner } from './icons'
 
+type Suggestion = {
+  name: string
+  country?: string
+}
+
 export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
   const [q, setQ] = useState('')
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
-  const [suggestions, setSuggestions] = useState<string[]>([])
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([])
   const [open, setOpen] = useState(false)
   const [highlight, setHighlight] = useState(-1)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -59,7 +64,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
     } else if (e.key === 'Enter') {
       e.preventDefault()
       if (open && highlight >= 0 && suggestions[highlight]) {
-        selectSuggestion(suggestions[highlight])
+        selectSuggestion(suggestions[highlight].name)
       } else {
         handleSubmit(q)
       }
@@ -144,16 +149,19 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
             <div className="absolute inset-0 overflow-auto">
               {suggestions.map((s, i) => (
                 <motion.li
-                  key={s}
+                  key={s.name}
                   id={`suggest-${i}`}
                   role="option"
                   aria-selected={i === highlight}
                   className="relative z-[1] flex h-11 cursor-pointer items-center gap-3 px-4 text-sm"
                   onMouseEnter={() => setHighlight(i)}
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => selectSuggestion(s)}
+                  onClick={() => selectSuggestion(s.name)}
                 >
-                  <span className="truncate">{s}</span>
+                  <span className="truncate">
+                    {s.name}
+                    {s.country && <span className="text-neutral-500">, {s.country}</span>}
+                  </span>
                 </motion.li>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- include country metadata in `/api/suggest` results
- show country names next to city suggestions in lighter text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689d3d017ca8832f9f1a18be8ce6fa8a