### PR TITLE
Improve suggestion prefix matching

### DIFF
--- a/app/api/suggest/route.ts
+++ b/app/api/suggest/route.ts
@@ -44,7 +44,15 @@ export async function GET(req: NextRequest) {
   if (!key) return json({ suggestions: [] })
 
   const prefixMatches = entries
-    .filter(e => e.key.startsWith(key))
+    .filter(e => e.key.split(' ').some(w => w.startsWith(key)))
+    .sort((a, b) => {
+      const aCountry = a.country ? 1 : 0
+      const bCountry = b.country ? 1 : 0
+      if (aCountry !== bCountry) return aCountry - bCountry
+      return a.key.startsWith(key) === b.key.startsWith(key)
+        ? a.key.localeCompare(b.key)
+        : a.key.startsWith(key) ? -1 : 1
+    })
     .map(e => ({ ...e, distance: 0 }))
 
   const fuzzyMatches = key.length >= 3


### PR DESCRIPTION
## Summary
- Improve suggestion prefix matching so query matches words beyond the start

## Testing
- `npm run build`
- `curl -sS 'http://localhost:3000/api/suggest?q=korea'`


------
https://chatgpt.com/codex/tasks/task_b_689d4e820138832faf26371b9c2a63a6