### PR TITLE
Dismiss mobile keyboard after submitting search

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -45,6 +45,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
 
   function handleSubmit(value: string) {
     if (!value.trim()) return
+    inputRef.current?.blur()
     setState('loading')
     onSubmit(value)
     // state will be flipped to done by parent via props? We keep local animation:


### PR DESCRIPTION
## Summary
- blur search input when submitting so keyboard closes on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e919098e4832fa728b17a89e24a25