### PR TITLE
Add clear button to search bar

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { ArrowRight, Check, Spinner } from './icons'
+import { ArrowRight, Check, Spinner, XMark } from './icons'
 
 type Suggestion = {
   name: string
@@ -107,6 +107,24 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
           aria-controls="suggest-list"
           aria-activedescendant={highlight >= 0 ? `suggest-${highlight}` : undefined}
         />
+        {q && (
+          <button
+            type="button"
+            aria-label="Clear search"
+            title="Clear"
+            onClick={() => {
+              setQ('')
+              setSuggestions([])
+              setOpen(false)
+              setHighlight(-1)
+              setDisableSuggest(false)
+              inputRef.current?.focus()
+            }}
+            className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center text-neutral-400 hover:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+          >
+            <XMark />
+          </button>
+        )}
         <button
           aria-label="Search"
           onClick={() => handleSubmit(q)}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -16,6 +16,12 @@ export const Spinner = () => (
       <path d="M5 12h14M13 5l7 7-7 7" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   )
+
+  export const XMark = () => (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
+      <path d="M6 18L18 6M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
   
   export const Bolt = () => (
     <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden>


### PR DESCRIPTION
## Summary
- add cross icon for clearing search text
- show clear button in SearchBar with desktop hover tooltip

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689e991dae3c832f9cf430ffe901b05b