### PR TITLE
feat: stack search results

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,12 +25,11 @@ type LookupNoMatch = { query: string; status: 'no_match' } | { query: string; st
 export default function Page() {
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
   const [error, setError] = useState<string | null>(null)
-  const [result, setResult] = useState<LookupOk | null>(null)
+  const [results, setResults] = useState<LookupOk[]>([])
 
   async function onSubmit(q: string) {
     if (!q.trim()) return
     setError(null)
-    setResult(null)
     setState('loading')
 
     try {
@@ -43,7 +42,7 @@ export default function Page() {
         return
       }
 
-      setResult(data)
+      setResults((prev) => [data, ...prev])
       setState('done')
       setTimeout(() => setState('idle'), 800)
     } catch (e) {
@@ -64,7 +63,7 @@ export default function Page() {
         Type a <em>country</em> or <em>city</em>.
       </p>
 
-      <div className="mt-8 w-full" aria-live="polite">
+      <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (
           <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
             {error}
@@ -72,21 +71,34 @@ export default function Page() {
         )}
 
         <AnimatePresence>
-          {result && (
+          {results.map((result) => (
             <motion.div
-              key={result.version + result.resolved.countryCode}
+              key={result.version + result.resolved.countryCode + result.query}
+              layout
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -8 }}
             >
               <ResultCard data={result} />
             </motion.div>
-          )}
+          ))}
         </AnimatePresence>
       </div>
 
+      {results.length > 0 && (
+        <button
+          onClick={() => {
+            setResults([])
+            setError(null)
+          }}
+          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700"
+        >
+          Clear results
+        </button>
+      )}
+
       <footer className="mt-10 text-center text-xs text-neutral-500">
-        
+
       </footer>
     </div>
   )


### PR DESCRIPTION
## Summary
- preserve previous search results instead of replacing them
- provide a "Clear results" control to remove all stored results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_689e9bdd8cec832f88de1d75ef79bd4f