### PR TITLE
Fix city lookup for duplicate city names

### DIFF
--- a/app/api/lookup/route.ts
+++ b/app/api/lookup/route.ts
@@ -25,13 +25,18 @@ type Entry = {
 const data = merged as Entry[]
 const lookup = new Map<string, Entry>()
 for (const row of data) {
-  lookup.set(norm(row.country), row)
+  const countryKey = norm(row.country)
+  lookup.set(countryKey, row)
   lookup.set(norm(row.code), row)
   for (const city of row.cities ?? []) {
-    lookup.set(norm(city), row)
+    const cityKey = norm(city)
+    lookup.set(cityKey, row)
+    lookup.set(`${cityKey} ${countryKey}`, row)
   }
   for (const city of row.asciiname ?? []) {
-    lookup.set(norm(city), row)
+    const cityKey = norm(city)
+    lookup.set(cityKey, row)
+    lookup.set(`${cityKey} ${countryKey}`, row)
   }
 }
 
@@ -50,12 +55,19 @@ export async function GET(req: NextRequest) {
   }
 
   let city: string | undefined
-  if (norm(entry.country) !== key && norm(entry.code) !== key) {
-    const cityIdx = entry.cities?.findIndex(c => norm(c) === key)
+  const countryKey = norm(entry.country)
+  if (countryKey !== key && norm(entry.code) !== key) {
+    const cityIdx = entry.cities?.findIndex(c => {
+      const cKey = norm(c)
+      return cKey === key || `${cKey} ${countryKey}` === key
+    })
     if (cityIdx !== undefined && cityIdx >= 0 && entry.cities) {
       city = entry.cities[cityIdx]
     } else {
-      const asciiIdx = entry.asciiname?.findIndex(c => norm(c) === key)
+      const asciiIdx = entry.asciiname?.findIndex(c => {
+        const cKey = norm(c)
+        return cKey === key || `${cKey} ${countryKey}` === key
+      })
       if (asciiIdx !== undefined && asciiIdx >= 0) {
         if (entry.cities && entry.cities[asciiIdx]) {
           city = entry.cities[asciiIdx]

--- a/app/api/suggest/route.ts
+++ b/app/api/suggest/route.ts
@@ -24,19 +24,29 @@ type Suggestion = {
 }
 
 const data = merged as Entry[]
-const entriesMap = new Map<string, Suggestion>()
+const entries: { key: string; name: string; country?: string }[] = []
+const dedup = new Set<string>()
 for (const row of data) {
-  entriesMap.set(norm(row.country), { name: row.country })
+  entries.push({ key: norm(row.country), name: row.country })
+
   for (const city of row.cities ?? []) {
-    const key = norm(city)
-    if (!entriesMap.has(key)) entriesMap.set(key, { name: city, country: row.country })
+    const cityKey = norm(city)
+    const unique = `${cityKey}|${norm(row.country)}`
+    if (!dedup.has(unique)) {
+      dedup.add(unique)
+      entries.push({ key: cityKey, name: city, country: row.country })
+    }
   }
+
   for (const city of row.asciiname ?? []) {
-    const key = norm(city)
-    if (!entriesMap.has(key)) entriesMap.set(key, { name: city, country: row.country })
+    const cityKey = norm(city)
+    const unique = `${cityKey}|${norm(row.country)}`
+    if (!dedup.has(unique)) {
+      dedup.add(unique)
+      entries.push({ key: cityKey, name: city, country: row.country })
+    }
   }
 }
-const entries = Array.from(entriesMap, ([key, s]) => ({ key, ...s }))
 
 export async function GET(req: NextRequest) {
   const q = req.nextUrl.searchParams.get('q') ?? ''

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -68,7 +68,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
     } else if (e.key === 'Enter') {
       e.preventDefault()
       if (open && highlight >= 0 && suggestions[highlight]) {
-        selectSuggestion(suggestions[highlight].name)
+        selectSuggestion(suggestions[highlight])
       } else {
         handleSubmit(q)
       }
@@ -78,12 +78,13 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
     }
   }
 
-  function selectSuggestion(s: string) {
+  function selectSuggestion(s: Suggestion) {
     setDisableSuggest(true)
-    setQ(s)
+    const value = s.country ? `${s.name}, ${s.country}` : s.name
+    setQ(value)
     setOpen(false)
     setSuggestions([])
-    handleSubmit(s)
+    handleSubmit(value)
   }
 
   return (
@@ -183,7 +184,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
                   className="relative z-[1] flex h-11 cursor-pointer items-center gap-3 px-4 text-sm"
                   onMouseEnter={() => setHighlight(i)}
                   onMouseDown={(e) => e.preventDefault()}
-                  onClick={() => selectSuggestion(s.name)}
+                  onClick={() => selectSuggestion(s)}
                 >
                   <span className="truncate">
                     {s.name}


### PR DESCRIPTION
## Summary
- include country in suggestion data to allow duplicate city names
- submit country with city in search queries
- match lookup keys on `city country`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e9f7f8e38832fa2f146398f4cac06