### PR TITLE
feat: add automatic dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata, Viewport } from 'next'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 export const metadata: Metadata = {
   title: 'Plug Type Finder — Exact-Match MVP',
@@ -14,8 +15,24 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  if (stored === 'dark' || (!stored && prefersDark)) {
+    document.documentElement.classList.add('dark');
+  }
+})();`
+          }}
+        />
+      </head>
+      <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-900 dark:text-neutral-100">
+        <div className="absolute right-4 top-4">
+          <ThemeToggle />
+        </div>
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,13 +59,13 @@ export default function Page() {
 
       <SearchBar onSubmit={onSubmit} />
 
-      <p className="mt-3 text-sm text-neutral-600">
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
         Type a <em>country</em> or <em>city</em>.
       </p>
 
       <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700 dark:border-red-500/40 dark:bg-red-950 dark:text-red-300">
             {error}
           </div>
         )}
@@ -91,13 +91,13 @@ export default function Page() {
             setResults([])
             setError(null)
           }}
-          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700"
+          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
         >
           Clear results
         </button>
       )}
 
-      <footer className="mt-10 text-center text-xs text-neutral-500">
+      <footer className="mt-10 text-center text-xs text-neutral-500 dark:text-neutral-400">
 
       </footer>
     </div>

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -15,7 +15,7 @@ export function ResultCard({ data }: { data: {
   const verified = spec.lastVerified ? new Date(spec.lastVerified).toLocaleDateString() : '—'
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+    <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex items-center gap-2 text-lg font-semibold">
         <span className="text-2xl">{flagEmoji(resolved.countryCode)}</span>
@@ -24,13 +24,13 @@ export function ResultCard({ data }: { data: {
           {resolved.name ?? resolved.countryCode}
         </span>
       </div>
-        <span className="text-xs text-neutral-500 sm:text-right">Source: International Electrotechnical Commission</span>
+        <span className="text-xs text-neutral-500 sm:text-right dark:text-neutral-400">Source: International Electrotechnical Commission</span>
       </div>
 
 
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-neutral-600">Type(s)</span>
+          <span className="text-sm font-medium text-neutral-600 dark:text-neutral-300">Type(s)</span>
           <div className="flex flex-wrap gap-2">
             {spec.plugTypes.map((t) => (
               <motion.span
@@ -38,7 +38,7 @@ export function ResultCard({ data }: { data: {
                 initial={{ y: -4, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 24 }}
-                className="inline-flex h-8 min-w-8 items-center justify-center rounded-full border border-neutral-200 bg-white px-3 text-sm font-semibold shadow-sm"
+                className="inline-flex h-8 min-w-8 items-center justify-center rounded-full border border-neutral-200 bg-white px-3 text-sm font-semibold shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
               >
                 {t}
               </motion.span>
@@ -49,7 +49,7 @@ export function ResultCard({ data }: { data: {
         <div className="flex items-center gap-2">
           <Bolt />
           <div>
-            <div className="text-xs text-neutral-500">Voltage</div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">Voltage</div>
             <div className="text-base font-semibold">
               {spec.voltage.length === 2
                 ? `${spec.voltage[0]}–${spec.voltage[1]} V`
@@ -61,7 +61,7 @@ export function ResultCard({ data }: { data: {
         <div className="flex items-center gap-2">
           <Wave />
           <div>
-            <div className="text-xs text-neutral-500">Frequency</div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">Frequency</div>
             <div className="text-base font-semibold">{spec.frequencyHz} Hz</div>
           </div>
         </div>
@@ -69,19 +69,19 @@ export function ResultCard({ data }: { data: {
 
       <div className="mt-4">
         <details className="group">
-          <summary className="flex cursor-pointer list-none items-center justify-between text-sm text-neutral-700">
+          <summary className="flex cursor-pointer list-none items-center justify-between text-sm text-neutral-700 dark:text-neutral-300">
             <span>More details</span>
             <span aria-hidden className="ml-2 transition-transform group-open:rotate-90">▶</span>
           </summary>
-          <div className="pt-2 text-sm text-neutral-700">
+          <div className="pt-2 text-sm text-neutral-700 dark:text-neutral-300">
             <p className="mb-2"><strong>Safety tip:</strong> <em>Adapters change shape; converters change voltage.</em> US devices (120V) in 230V regions need a converter, not just an adapter.</p>
             {spec.notes && <p className="mb-2">{spec.notes}</p>}
-            <p className="text-xs text-neutral-500">Confidence: {(data.confidence * 100).toFixed(0)}%</p>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">Confidence: {(data.confidence * 100).toFixed(0)}%</p>
           </div>
         </details>
       </div>
 
-      <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-3 text-sm">
+      <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-3 text-sm dark:border-neutral-700 dark:bg-neutral-800">
         <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
           <span className="text-center sm:text-left">Want one charger for everywhere? <strong>P3 Pro</strong> works in every country.</span>
           <a

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -90,7 +90,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
   return (
     <div className="relative w-full">
       <label htmlFor="where" className="sr-only">Destination</label>
-      <div className="flex w-full items-center rounded-full border border-neutral-200 bg-white pl-5 pr-2 shadow-sm transition-shadow duration-150">        
+      <div className="flex w-full items-center rounded-full border border-neutral-200 bg-white pl-5 pr-2 shadow-sm transition-shadow duration-150 dark:border-neutral-700 dark:bg-neutral-800">
         <input
           id="where"
           ref={inputRef}
@@ -102,7 +102,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
           onKeyDown={onKeyDown}
           placeholder="I’m going to…"
           autoComplete="off"
-          className="h-14 w-full rounded-full bg-transparent text-base outline-none placeholder:text-neutral-400"
+          className="h-14 w-full rounded-full bg-transparent text-base outline-none placeholder:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-500"
           aria-autocomplete="list"
           aria-expanded={open}
           aria-controls="suggest-list"
@@ -121,7 +121,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
               setDisableSuggest(false)
               inputRef.current?.focus()
             }}
-            className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center text-neutral-400 hover:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+            className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center text-neutral-400 hover:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 dark:text-neutral-500 dark:hover:text-neutral-300"
           >
             <XMark />
           </button>
@@ -161,7 +161,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -2 }}
             transition={{ duration: 0.12 }}
-            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg relative"
+            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg relative dark:border-neutral-700 dark:bg-neutral-800"
             style={{ height: Math.min(8, suggestions.length) * ITEM_H }}
           >
             {highlight >= 0 && (
@@ -171,7 +171,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
                 initial={false}
                 animate={{ y: markerY }}
                 transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className="pointer-events-none absolute left-0 top-0 h-11 w-full rounded-md bg-neutral-100"
+                className="pointer-events-none absolute left-0 top-0 h-11 w-full rounded-md bg-neutral-100 dark:bg-neutral-700"
               />
             )}
             <div className="absolute inset-0 overflow-auto">
@@ -188,7 +188,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
                 >
                   <span className="truncate">
                     {s.name}
-                    {s.country && <span className="text-neutral-500">, {s.country}</span>}
+                    {s.country && <span className="text-neutral-500 dark:text-neutral-400">, {s.country}</span>}
                   </span>
                 </motion.li>
               ))}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Sun, Moon } from './icons'
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light'
+    return document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      root.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
+  }, [theme])
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    const listener = (e: MediaQueryListEvent) => {
+      const stored = localStorage.getItem('theme')
+      if (!stored) {
+        setTheme(e.matches ? 'dark' : 'light')
+      }
+    }
+    mql.addEventListener('change', listener)
+    return () => mql.removeEventListener('change', listener)
+  }, [])
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      className="rounded-full p-2 text-neutral-600 hover:bg-neutral-200 dark:text-neutral-300 dark:hover:bg-neutral-700"
+    >
+      {theme === 'dark' ? <Sun /> : <Moon />}
+    </button>
+  )
+}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -34,4 +34,17 @@ export const Spinner = () => (
       <path d="M2 12c2 0 2-4 4-4s2 4 4 4 2-4 4-4 2 4 4 4 2-4 4-4" strokeLinecap="round" />
     </svg>
   )
+
+  export const Sun = () => (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <circle cx="12" cy="12" r="5" />
+      <path strokeLinecap="round" d="M12 1v2m0 18v2m11-11h-2M3 12H1m16.95 7.95l-1.414-1.414M6.464 6.464 5.05 5.05m12.728 0-1.414 1.414M6.464 17.536 5.05 18.95" />
+    </svg>
+  )
+
+  export const Moon = () => (
+    <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+    </svg>
+  )
   

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 export default {
+  darkMode: 'class',
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}'


### PR DESCRIPTION
## Summary
- add class-based dark mode to Tailwind config
- implement theme toggle and system preference detection
- style components for dark theme with sun/moon switcher

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689fe4917bac832fbcc7e3fa1605b3e1