### PR TITLE
Add dark mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css'
 import type { Metadata, Viewport } from 'next'
+import { ThemeToggle } from '@/components/ThemeToggle'
 
 export const metadata: Metadata = {
   title: 'Plug Type Finder — Exact-Match MVP',
@@ -15,7 +16,8 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased">
+      <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-900 dark:text-neutral-50">
+        <ThemeToggle />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,13 +59,13 @@ export default function Page() {
 
       <SearchBar onSubmit={onSubmit} />
 
-      <p className="mt-3 text-sm text-neutral-600">
+      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
         Type a <em>country</em> or <em>city</em>.
       </p>
 
       <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300">
             {error}
           </div>
         )}
@@ -91,13 +91,13 @@ export default function Page() {
             setResults([])
             setError(null)
           }}
-          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700"
+          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
         >
           Clear results
         </button>
       )}
 
-      <footer className="mt-10 text-center text-xs text-neutral-500">
+      <footer className="mt-10 text-center text-xs text-neutral-500 dark:text-neutral-400">
 
       </footer>
     </div>

--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -18,7 +18,7 @@ export function ResultCard({ data }: { data: {
   const showP3Pro = resolved.countryCode !== 'SZ' && resolved.countryCode !== 'LS'
 
   return (
-    <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm">
+    <div className="rounded-2xl border border-neutral-200 bg-white p-5 shadow-sm dark:border-neutral-700 dark:bg-neutral-800">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
       <div className="flex items-center gap-2 text-lg font-semibold">
         <span className="text-2xl">{flagEmoji(resolved.countryCode)}</span>
@@ -27,13 +27,13 @@ export function ResultCard({ data }: { data: {
           {resolved.name ?? resolved.countryCode}
         </span>
       </div>
-        <span className="text-xs text-neutral-500 sm:text-right">Source: International Electrotechnical Commission</span>
+        <span className="text-xs text-neutral-500 sm:text-right dark:text-neutral-400">Source: International Electrotechnical Commission</span>
       </div>
 
 
       <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-neutral-600">Type(s)</span>
+          <span className="text-sm font-medium text-neutral-600 dark:text-neutral-300">Type(s)</span>
           <div className="flex flex-wrap gap-2">
             {spec.plugTypes.map((t) => (
               <motion.span
@@ -41,7 +41,7 @@ export function ResultCard({ data }: { data: {
                 initial={{ y: -4, opacity: 0 }}
                 animate={{ y: 0, opacity: 1 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 24 }}
-                className="inline-flex h-8 min-w-8 items-center justify-center rounded-full border border-neutral-200 bg-white px-3 text-sm font-semibold shadow-sm"
+                className="inline-flex h-8 min-w-8 items-center justify-center rounded-full border border-neutral-200 bg-white px-3 text-sm font-semibold shadow-sm dark:border-neutral-700 dark:bg-neutral-800"
               >
                 {t}
               </motion.span>
@@ -52,7 +52,7 @@ export function ResultCard({ data }: { data: {
         <div className="flex items-center gap-2">
           <Bolt />
           <div>
-            <div className="text-xs text-neutral-500">Voltage</div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">Voltage</div>
             <div className="text-base font-semibold">
               {spec.voltage.length === 2
                 ? `${spec.voltage[0]}–${spec.voltage[1]} V`
@@ -64,7 +64,7 @@ export function ResultCard({ data }: { data: {
         <div className="flex items-center gap-2">
           <Wave />
           <div>
-            <div className="text-xs text-neutral-500">Frequency</div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">Frequency</div>
             <div className="text-base font-semibold">{spec.frequencyHz} Hz</div>
           </div>
         </div>
@@ -72,20 +72,20 @@ export function ResultCard({ data }: { data: {
 
       <div className="mt-4">
         <details className="group">
-          <summary className="flex cursor-pointer list-none items-center justify-between text-sm text-neutral-700">
+          <summary className="flex cursor-pointer list-none items-center justify-between text-sm text-neutral-700 dark:text-neutral-300">
             <span>More details</span>
             <span aria-hidden className="ml-2 transition-transform group-open:rotate-90">▶</span>
           </summary>
-          <div className="pt-2 text-sm text-neutral-700">
+          <div className="pt-2 text-sm text-neutral-700 dark:text-neutral-300">
             <p className="mb-2"><strong>Safety tip:</strong> <em>Adapters change shape; converters change voltage.</em> US devices (120V) in 230V regions need a converter, not just an adapter.</p>
             {spec.notes && <p className="mb-2">{spec.notes}</p>}
-            <p className="text-xs text-neutral-500">Confidence: {(data.confidence * 100).toFixed(0)}%</p>
+            <p className="text-xs text-neutral-500 dark:text-neutral-400">Confidence: {(data.confidence * 100).toFixed(0)}%</p>
           </div>
         </details>
       </div>
 
       {showP3Pro && (
-        <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-3 text-sm">
+        <div className="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-3 text-sm dark:border-neutral-700 dark:bg-neutral-900">
           <div className="flex flex-col items-center justify-between gap-3 sm:flex-row">
             <span className="text-center sm:text-left">
               {`Want a charger for ${location}? `}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -90,7 +90,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
   return (
     <div className="relative w-full">
       <label htmlFor="where" className="sr-only">Destination</label>
-      <div className="flex w-full items-center rounded-full border border-neutral-200 bg-white pl-5 pr-2 shadow-sm transition-shadow duration-150">        
+      <div className="flex w-full items-center rounded-full border border-neutral-200 bg-white pl-5 pr-2 shadow-sm transition-shadow duration-150 dark:border-neutral-700 dark:bg-neutral-800">
         <input
           id="where"
           ref={inputRef}
@@ -102,7 +102,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
           onKeyDown={onKeyDown}
           placeholder="I’m going to…"
           autoComplete="off"
-          className="h-14 w-full rounded-full bg-transparent text-base outline-none placeholder:text-neutral-400"
+          className="h-14 w-full rounded-full bg-transparent text-base outline-none placeholder:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-500"
           aria-autocomplete="list"
           aria-expanded={open}
           aria-controls="suggest-list"
@@ -121,7 +121,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
               setDisableSuggest(false)
               inputRef.current?.focus()
             }}
-            className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center text-neutral-400 hover:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
+            className="ml-2 inline-flex h-8 w-8 shrink-0 items-center justify-center text-neutral-400 hover:text-neutral-600 focus:outline-none focus:ring-2 focus:ring-emerald-600 dark:hover:text-neutral-200 dark:focus:ring-neutral-400"
           >
             <XMark />
           </button>
@@ -161,7 +161,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -2 }}
             transition={{ duration: 0.12 }}
-            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg relative"
+            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg relative dark:border-neutral-700 dark:bg-neutral-800"
             style={{ height: Math.min(8, suggestions.length) * ITEM_H }}
           >
             {highlight >= 0 && (
@@ -171,7 +171,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
                 initial={false}
                 animate={{ y: markerY }}
                 transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-                className="pointer-events-none absolute left-0 top-0 h-11 w-full rounded-md bg-neutral-100"
+                className="pointer-events-none absolute left-0 top-0 h-11 w-full rounded-md bg-neutral-100 dark:bg-neutral-700"
               />
             )}
             <div className="absolute inset-0 overflow-auto">
@@ -181,15 +181,15 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
                   id={`suggest-${i}`}
                   role="option"
                   aria-selected={i === highlight}
-                  className="relative z-[1] flex h-11 cursor-pointer items-center gap-3 px-4 text-sm"
+                  className="relative z-[1] flex h-11 cursor-pointer items-center gap-3 px-4 text-sm text-neutral-900 dark:text-neutral-100"
                   onMouseEnter={() => setHighlight(i)}
                   onMouseDown={(e) => e.preventDefault()}
                   onClick={() => selectSuggestion(s)}
                 >
                   <span className="truncate">
                     {s.name}
-                    {s.country && <span className="text-neutral-500">, {s.country}</span>}
-                  </span>
+                    {s.country && <span className="text-neutral-500 dark:text-neutral-400">, {s.country}</span>}
+                </span>
                 </motion.li>
               ))}
             </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from './icons'
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
+    typeof window !== 'undefined' && window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
+  )
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('theme', theme)
+    }
+  }, [theme])
+
+  return (
+    <button
+      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      aria-label="Toggle dark mode"
+      className="fixed right-4 top-4 rounded-full border border-neutral-200 bg-white p-2 text-neutral-700 shadow-sm transition-colors hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:ring-neutral-400"
+    >
+      {theme === 'dark' ? <Sun /> : <Moon />}
+    </button>
+  )
+}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -29,9 +29,22 @@ export const Spinner = () => (
     </svg>
   )
   
-  export const Wave = () => (
+export const Wave = () => (
     <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
       <path d="M2 12c2 0 2-4 4-4s2 4 4 4 2-4 4-4 2 4 4 4 2-4 4-4" strokeLinecap="round" />
     </svg>
   )
+
+export const Sun = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <circle cx="12" cy="12" r="4" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.364 6.364l-1.414-1.414M6.05 6.05L4.636 4.636m12.728 0l-1.414 1.414M6.05 17.95l-1.414 1.414" />
+  </svg>
+)
+
+export const Moon = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+  </svg>
+)
   

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss'
 
 export default {
+  darkMode: 'class',
   content: [
     './app/**/*.{ts,tsx}',
     './components/**/*.{ts,tsx}'


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- add theme toggle button with sun and moon icons
- update pages and components to support dark palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ff4a1d7c0832fa96be87fe1d4734c