### PR TITLE
Respect system color scheme on load

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css'
+import Script from 'next/script'
 import type { Metadata, Viewport } from 'next'
 import { ThemeToggle } from '@/components/ThemeToggle'
 
@@ -16,6 +17,21 @@ export const viewport: Viewport = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <Script id="theme-script" strategy="beforeInteractive">
+          {`
+            (() => {
+              const stored = localStorage.getItem('theme');
+              const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+              if (stored === 'dark' || (!stored && prefersDark)) {
+                document.documentElement.classList.add('dark');
+              } else {
+                document.documentElement.classList.remove('dark');
+              }
+            })();
+          `}
+        </Script>
+      </head>
       <body className="min-h-screen bg-neutral-50 text-neutral-900 antialiased dark:bg-neutral-900 dark:text-neutral-50">
         <ThemeToggle />
         {children}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -4,25 +4,37 @@ import { useEffect, useState } from 'react'
 import { Moon, Sun } from './icons'
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
-    typeof window !== 'undefined' && window.localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
-  )
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === 'undefined') return 'light'
+    const stored = window.localStorage.getItem('theme') as 'light' | 'dark' | null
+    if (stored) return stored
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
 
   useEffect(() => {
-    const root = document.documentElement
-    if (theme === 'dark') {
-      root.classList.add('dark')
-    } else {
-      root.classList.remove('dark')
-    }
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem('theme', theme)
-    }
+    document.documentElement.classList.toggle('dark', theme === 'dark')
   }, [theme])
+
+  useEffect(() => {
+    const media = window.matchMedia('(prefers-color-scheme: dark)')
+    const stored = window.localStorage.getItem('theme')
+    if (stored) return
+    const listener = (e: MediaQueryListEvent) => {
+      setTheme(e.matches ? 'dark' : 'light')
+    }
+    media.addEventListener('change', listener)
+    return () => media.removeEventListener('change', listener)
+  }, [])
+
+  const toggleTheme = () => {
+    const nextTheme = theme === 'dark' ? 'light' : 'dark'
+    setTheme(nextTheme)
+    window.localStorage.setItem('theme', nextTheme)
+  }
 
   return (
     <button
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+      onClick={toggleTheme}
       aria-label="Toggle dark mode"
       className="fixed right-4 top-4 rounded-full border border-neutral-200 bg-white p-2 text-neutral-700 shadow-sm transition-colors hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:ring-neutral-400"
     >


### PR DESCRIPTION
## Summary
- initialize site theme from system preference via startup script
- update theme toggle to default to system preference and persist manual changes

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_689ff6acd1fc832fb69c3753e7497695