### PR TITLE
fix: render theme icons after mount

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Moon, Sun } from './icons'
 
 export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false)
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (typeof window === 'undefined') return 'light'
     const stored = window.localStorage.getItem('theme') as 'light' | 'dark' | null
@@ -14,6 +15,10 @@ export function ThemeToggle() {
   useEffect(() => {
     document.documentElement.classList.toggle('dark', theme === 'dark')
   }, [theme])
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
 
   useEffect(() => {
     const media = window.matchMedia('(prefers-color-scheme: dark)')
@@ -38,7 +43,7 @@ export function ThemeToggle() {
       aria-label="Toggle dark mode"
       className="fixed right-4 top-4 rounded-full border border-neutral-200 bg-white p-2 text-neutral-700 shadow-sm transition-colors hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-emerald-600 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700 dark:focus:ring-neutral-400"
     >
-      {theme === 'dark' ? <Sun /> : <Moon />}
+      {mounted ? (theme === 'dark' ? <Sun /> : <Moon />) : null}
     </button>
   )
 }


### PR DESCRIPTION
## Summary
- avoid hydration mismatch by rendering theme icons after mount

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ff8e64e34832f8199d56a087617f1