### PR TITLE
chore: update next to latest 14.x patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "framer-motion": "^11.3.31",
-                "next": "^14.2.5",
+                "next": "^14.2.31",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1"
             },
@@ -94,15 +94,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
-            "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.31.tgz",
+            "integrity": "sha512-X8VxxYL6VuezrG82h0pUA1V+DuTSJp7Nv15bxq3ivrFqZLjx81rfeHMWOE9T0jm1n3DtHGv8gdn6B0T0kr0D3Q==",
             "license": "MIT"
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
-            "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.31.tgz",
+            "integrity": "sha512-dTHKfaFO/xMJ3kzhXYgf64VtV6MMwDs2viedDOdP+ezd0zWMOQZkxcwOfdcQeQCpouTr9b+xOqMCUXxgLizl8Q==",
             "cpu": [
                 "arm64"
             ],
@@ -116,9 +116,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
-            "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.31.tgz",
+            "integrity": "sha512-iSavebQgeMukUAfjfW8Fi2Iz01t95yxRl2w2wCzjD91h5In9la99QIDKcKSYPfqLjCgwz3JpIWxLG6LM/sxL4g==",
             "cpu": [
                 "x64"
             ],
@@ -132,9 +132,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
-            "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.31.tgz",
+            "integrity": "sha512-XJb3/LURg1u1SdQoopG6jDL2otxGKChH2UYnUTcby4izjM0il7ylBY5TIA7myhvHj9lG5pn9F2nR2s3i8X9awQ==",
             "cpu": [
                 "arm64"
             ],
@@ -148,9 +148,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
-            "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.31.tgz",
+            "integrity": "sha512-IInDAcchNCu3BzocdqdCv1bKCmUVO/bKJHnBFTeq3svfaWpOPewaLJ2Lu3GL4yV76c/86ZvpBbG/JJ1lVIs5MA==",
             "cpu": [
                 "arm64"
             ],
@@ -164,9 +164,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
-            "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.31.tgz",
+            "integrity": "sha512-YTChJL5/9e4NXPKW+OJzsQa42RiWUNbE+k+ReHvA+lwXk+bvzTsVQboNcezWOuCD+p/J+ntxKOB/81o0MenBhw==",
             "cpu": [
                 "x64"
             ],
@@ -180,9 +180,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
-            "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.31.tgz",
+            "integrity": "sha512-A0JmD1y4q/9ufOGEAhoa60Sof++X10PEoiWOH0gZ2isufWZeV03NnyRlRmJpRQWGIbRkJUmBo9I3Qz5C10vx4w==",
             "cpu": [
                 "x64"
             ],
@@ -196,9 +196,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
-            "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.31.tgz",
+            "integrity": "sha512-nowJ5GbMeDOMzbTm29YqrdrD6lTM8qn2wnZfGpYMY7SZODYYpaJHH1FJXE1l1zWICHR+WfIMytlTDBHu10jb8A==",
             "cpu": [
                 "arm64"
             ],
@@ -212,9 +212,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
-            "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.31.tgz",
+            "integrity": "sha512-pk9Bu4K0015anTS1OS9d/SpS0UtRObC+xe93fwnm7Gvqbv/W1ZbzhK4nvc96RURIQOux3P/bBH316xz8wjGSsA==",
             "cpu": [
                 "ia32"
             ],
@@ -228,9 +228,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
-            "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.31.tgz",
+            "integrity": "sha512-LwFZd4JFnMHGceItR9+jtlMm8lGLU/IPkgjBBgYmdYSfalbHCiDpjMYtgDQ2wtwiAOSJOCyFI4m8PikrsDyA6Q==",
             "cpu": [
                 "x64"
             ],
@@ -1124,12 +1124,12 @@
             }
         },
         "node_modules/next": {
-            "version": "14.2.5",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
-            "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+            "version": "14.2.31",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.31.tgz",
+            "integrity": "sha512-Wyw1m4t8PhqG+or5a1U/Deb888YApC4rAez9bGhHkTsfwAy4SWKVro0GhEx4sox1856IbLhvhce2hAA6o8vkog==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "14.2.5",
+                "@next/env": "14.2.31",
                 "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
@@ -1144,15 +1144,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.5",
-                "@next/swc-darwin-x64": "14.2.5",
-                "@next/swc-linux-arm64-gnu": "14.2.5",
-                "@next/swc-linux-arm64-musl": "14.2.5",
-                "@next/swc-linux-x64-gnu": "14.2.5",
-                "@next/swc-linux-x64-musl": "14.2.5",
-                "@next/swc-win32-arm64-msvc": "14.2.5",
-                "@next/swc-win32-ia32-msvc": "14.2.5",
-                "@next/swc-win32-x64-msvc": "14.2.5"
+                "@next/swc-darwin-arm64": "14.2.31",
+                "@next/swc-darwin-x64": "14.2.31",
+                "@next/swc-linux-arm64-gnu": "14.2.31",
+                "@next/swc-linux-arm64-musl": "14.2.31",
+                "@next/swc-linux-x64-gnu": "14.2.31",
+                "@next/swc-linux-x64-musl": "14.2.31",
+                "@next/swc-win32-arm64-msvc": "14.2.31",
+                "@next/swc-win32-ia32-msvc": "14.2.31",
+                "@next/swc-win32-x64-msvc": "14.2.31"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "framer-motion": "^11.3.31",
-        "next": "^14.2.5",
+        "next": "^14.2.31",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
     },


### PR DESCRIPTION
## Summary
- update Next.js dependency to latest 14.x patch

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`
- `npm run dev` (outputs warning about unrecognized `reactCompiler` option)

------
https://chatgpt.com/codex/tasks/task_b_689ff9ef3908832f9550f7e6b625e09c