### PR TITLE
fix: stabilize search bar during suggestions

### DIFF
--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -161,7 +161,7 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -2 }}
             transition={{ duration: 0.12 }}
-            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg relative dark:border-neutral-700 dark:bg-neutral-800"
+            className="absolute z-10 mt-2 w-full overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800"
             style={{ height: Math.min(8, suggestions.length) * ITEM_H }}
           >
             {highlight >= 0 && (


### PR DESCRIPTION
## Summary
- prevent search bar from shifting when suggestion count changes by keeping suggestions dropdown absolutely positioned

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a66f0286ec832f81e64e2987c46c17