### PR TITLE
Avoid wrapping CTA text

### DIFF
--- a/components/ResultCard.tsx
+++ b/components/ResultCard.tsx
@@ -93,7 +93,7 @@ export function ResultCard({ data }: { data: {
               {` works in ${country} — and anywhere else.`}
             </span>
             <a
-              className="group relative inline-flex items-center justify-center overflow-hidden rounded-full bg-emerald-500 px-3 py-1.5 font-medium text-white hover:bg-emerald-600"
+              className="group relative inline-flex shrink-0 items-center justify-center overflow-hidden whitespace-nowrap rounded-full bg-emerald-500 px-3 py-1.5 font-medium text-white hover:bg-emerald-600"
               href="https://infinacore.com/products/p3-pro"
               target="_blank"
               rel="noreferrer"


### PR DESCRIPTION
## Summary
- prevent the "Learn more" CTA from wrapping onto two lines by keeping button text on one line

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a67188dc68832fa40224502dc42ba7