### PR TITLE
feat: add smart suggestions and CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ResultCard } from '@/components/ResultCard'
-import { SearchBar } from '@/components/SearchBar'
+import { SearchBar, SearchBarHandle } from '@/components/SearchBar'
+import { SmartSuggestions } from '@/components/SmartSuggestions'
 
 type LookupOk = {
   query: string
@@ -26,6 +27,7 @@ export default function Page() {
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
   const [error, setError] = useState<string | null>(null)
   const [results, setResults] = useState<LookupOk[]>([])
+  const searchRef = useRef<SearchBarHandle>(null)
 
   async function onSubmit(q: string) {
     if (!q.trim()) return
@@ -57,11 +59,13 @@ export default function Page() {
         What plug type do I need?
       </h1>
 
-      <SearchBar onSubmit={onSubmit} />
+        <SearchBar ref={searchRef} onSubmit={onSubmit} />
 
-      <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
-        Type a <em>country</em> or <em>city</em>.
-      </p>
+        <SmartSuggestions onSelect={(country) => searchRef.current?.setValue(country)} />
+
+        <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
+          Type a <em>country</em> or <em>city</em>.
+        </p>
 
       <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (
@@ -85,21 +89,30 @@ export default function Page() {
         </AnimatePresence>
       </div>
 
-      {results.length > 0 && (
-        <button
-          onClick={() => {
-            setResults([])
-            setError(null)
-          }}
-          className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+        {results.length > 0 && (
+          <button
+            onClick={() => {
+              setResults([])
+              setError(null)
+            }}
+            className="mt-4 text-xs text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+          >
+            Clear results
+          </button>
+        )}
+
+        <a
+          href="https://infinacore.com/products/p3-pro"
+          target="_blank"
+          rel="noreferrer"
+          className="mt-12 inline-flex items-center justify-center rounded-full bg-emerald-500 px-6 py-3 font-semibold text-white shadow-lg transition-colors hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-600"
         >
-          Clear results
-        </button>
-      )}
+          Get the P3 Pro — works in every country
+        </a>
 
-      <footer className="mt-10 text-center text-xs text-neutral-500 dark:text-neutral-400">
+        <footer className="mt-10 text-center text-xs text-neutral-500 dark:text-neutral-400">
 
-      </footer>
-    </div>
-  )
-}
+        </footer>
+      </div>
+    )
+  }

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, forwardRef, useImperativeHandle } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ArrowRight, Check, Spinner, XMark } from './icons'
 
@@ -9,7 +9,12 @@ type Suggestion = {
   country?: string
 }
 
-export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
+export type SearchBarHandle = {
+  setValue: (v: string) => void
+}
+
+export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => void }>(
+  function SearchBar({ onSubmit }, ref) {
   const [q, setQ] = useState('')
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
@@ -19,6 +24,17 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const ITEM_H = 44
   const markerY = highlight >= 0 ? highlight * ITEM_H : -9999
+
+  useImperativeHandle(ref, () => ({
+    setValue(value: string) {
+      setDisableSuggest(true)
+      setQ(value)
+      setOpen(false)
+      setSuggestions([])
+      setHighlight(-1)
+      inputRef.current?.focus()
+    },
+  }))
 
   useEffect(() => {
     let t: number | undefined
@@ -198,4 +214,4 @@ export function SearchBar({ onSubmit }: { onSubmit: (q: string) => void }) {
       </AnimatePresence>
     </div>
   )
-}
+})

--- a/components/SmartSuggestions.tsx
+++ b/components/SmartSuggestions.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { flagEmoji } from '@/lib/flags'
+
+const ORIGIN = {
+  name: 'United States',
+  plugTypes: ['Type A', 'Type B'],
+}
+
+const SUGGESTIONS = [
+  {
+    code: 'GB',
+    name: 'United Kingdom',
+    plugTypes: ['Type G'],
+    voltage: '230V',
+    frequency: '50Hz',
+  },
+  {
+    code: 'JP',
+    name: 'Japan',
+    plugTypes: ['Type A', 'Type B'],
+    voltage: '100V',
+    frequency: '50/60Hz',
+  },
+  {
+    code: 'MX',
+    name: 'Mexico',
+    plugTypes: ['Type A', 'Type B'],
+    voltage: '127V',
+    frequency: '60Hz',
+  },
+]
+
+type Props = {
+  onSelect: (country: string) => void
+}
+
+export function SmartSuggestions({ onSelect }: Props) {
+  const origin = ORIGIN
+  return (
+    <div className="mt-6 w-full">
+      <div className="mb-2 flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
+        <span>Smart suggestions (from {origin.name})</span>
+        <span>Swipe →</span>
+      </div>
+      <div className="flex gap-3 overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        {SUGGESTIONS.map((s, i) => {
+          const needsAdapter = !s.plugTypes.some(pt => origin.plugTypes.includes(pt))
+          const p3Ready = s.code !== 'SZ' && s.code !== 'LS'
+          return (
+            <motion.button
+              key={s.code}
+              onClick={() => onSelect(s.name)}
+              initial={{ opacity: 0, x: 24 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: i * 0.1 }}
+              className="relative flex w-64 shrink-0 flex-col rounded-xl border border-neutral-200 bg-white p-4 text-left shadow-sm transition-transform hover:-translate-y-0.5 hover:shadow-md focus:outline-none active:scale-95 dark:border-neutral-700 dark:bg-neutral-800"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-2xl">{flagEmoji(s.code)}</span>
+                <span className={`rounded-full px-2 py-0.5 text-xs ${needsAdapter ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300' : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'}`}>{needsAdapter ? 'Needs adapter' : 'No adapter needed'}</span>
+              </div>
+              <div className="mt-2 text-lg font-semibold">{s.name}</div>
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">From {origin.name} → {needsAdapter ? 'Needs adapter' : 'No adapter needed'}</div>
+              <div className="mt-2 mb-2 flex flex-wrap gap-1">
+                {s.plugTypes.map(pt => (
+                  <span key={pt} className="rounded-full bg-neutral-100 px-2 py-0.5 text-xs text-neutral-700 dark:bg-neutral-700 dark:text-neutral-100">{pt}</span>
+                ))}
+              </div>
+              <div className="text-xs text-neutral-500 dark:text-neutral-400">{s.voltage} • {s.frequency}</div>
+              <div className="mt-3 flex items-center justify-between text-xs">
+                <span className="text-neutral-400 dark:text-neutral-500">Tap to autofill</span>
+                <span className={`rounded-full px-2 py-0.5 ${p3Ready ? 'bg-emerald-600 text-white' : 'bg-neutral-300 text-neutral-600 dark:bg-neutral-600 dark:text-neutral-300'}`}>{p3Ready ? 'P3 Pro ready' : 'Check compatibility'}</span>
+              </div>
+            </motion.button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- expose SearchBar ref to allow external autofill
- add horizontally scrollable smart suggestion cards with plug details and P3 Pro badge
- include bottom CTA button promoting P3 Pro

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a67527ce2c832f8b87c38ec187d270