### PR TITLE
Add desktop arrow to smart suggestions

### DIFF
--- a/components/SmartSuggestions.tsx
+++ b/components/SmartSuggestions.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { flagEmoji } from '@/lib/flags'
+import { ArrowRight } from './icons'
 
 const ORIGIN = {
   name: 'United States',
@@ -42,7 +43,9 @@ export function SmartSuggestions({ onSelect }: Props) {
     <div className="mt-6 w-full">
       <div className="mb-2 flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
         <span>Smart suggestions (from {origin.name})</span>
-        <span>Swipe →</span>
+        <span className="hidden md:inline-block" aria-hidden>
+          <ArrowRight />
+        </span>
       </div>
       <div className="flex gap-3 overflow-x-auto pb-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         {SUGGESTIONS.map((s, i) => {


### PR DESCRIPTION
## Summary
- show a right arrow on desktop and drop mobile swipe text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a678eeca58832fa0b3e6dac69a1126