### PR TITLE
Add bidirectional slider arrows with translucent styling

### DIFF
--- a/components/SmartSuggestions.tsx
+++ b/components/SmartSuggestions.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import { flagEmoji } from '@/lib/flags'
-import { ArrowRight } from './icons'
+import { ArrowLeft, ArrowRight } from './icons'
 
 const ORIGIN = {
   name: 'United States',
@@ -104,6 +104,23 @@ type Props = {
 export function SmartSuggestions({ onSelect }: Props) {
   const origin = ORIGIN
   const scrollRef = useRef<HTMLDivElement>(null)
+  const [canScrollLeft, setCanScrollLeft] = useState(false)
+  const [canScrollRight, setCanScrollRight] = useState(true)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const update = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el
+      setCanScrollLeft(scrollLeft > 0)
+      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1)
+    }
+
+    update()
+    el.addEventListener('scroll', update)
+    return () => el.removeEventListener('scroll', update)
+  }, [])
 
   return (
     <div className="mt-6 w-full">
@@ -149,9 +166,17 @@ export function SmartSuggestions({ onSelect }: Props) {
         </div>
         <button
           type="button"
-          className="hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white p-2 shadow-sm hover:shadow-md dark:bg-neutral-800"
+          className={`absolute left-0 top-1/2 hidden -translate-y-1/2 items-center justify-center rounded-full border border-neutral-200/70 bg-white/70 p-2 shadow-sm backdrop-blur-md hover:shadow-md dark:border-neutral-700/70 dark:bg-neutral-800/70 md:flex ${canScrollLeft ? '' : 'invisible'}`}
+          onClick={() => scrollRef.current?.scrollBy({ left: -(scrollRef.current?.clientWidth ?? 0), behavior: 'smooth' })}
+          aria-label="Scroll suggestions left"
+        >
+          <ArrowLeft />
+        </button>
+        <button
+          type="button"
+          className={`absolute right-0 top-1/2 hidden -translate-y-1/2 items-center justify-center rounded-full border border-neutral-200/70 bg-white/70 p-2 shadow-sm backdrop-blur-md hover:shadow-md dark:border-neutral-700/70 dark:bg-neutral-800/70 md:flex ${canScrollRight ? '' : 'invisible'}`}
           onClick={() => scrollRef.current?.scrollBy({ left: scrollRef.current?.clientWidth ?? 0, behavior: 'smooth' })}
-          aria-label="Scroll suggestions"
+          aria-label="Scroll suggestions right"
         >
           <ArrowRight />
         </button>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -17,6 +17,12 @@ export const Spinner = () => (
     </svg>
   )
 
+export const ArrowLeft = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
+    <path d="M19 12H5m6-7l-7 7 7 7" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+)
+
   export const XMark = () => (
     <svg className="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" aria-hidden>
       <path d="M6 18L18 6M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" />


### PR DESCRIPTION
## Summary
- add ArrowLeft icon for navigation
- show/hide left/right arrow buttons on SmartSuggestions slider and style buttons with translucent glass-like background

## Testing
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a67e7534c0832fa03ca720c0aa73a7