### PR TITLE
Trigger search when selecting smart suggestions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
 
         <SearchBar ref={searchRef} onSubmit={onSubmit} />
 
-        <SmartSuggestions onSelect={(country) => searchRef.current?.setValue(country)} />
+        <SmartSuggestions onSelect={(country) => searchRef.current?.search(country)} />
 
         <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
           Type a <em>country</em> or <em>city</em>.

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -11,6 +11,7 @@ type Suggestion = {
 
 export type SearchBarHandle = {
   setValue: (v: string) => void
+  search: (v: string) => void
 }
 
 export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => void }>(
@@ -33,6 +34,14 @@ export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => 
       setSuggestions([])
       setHighlight(-1)
       inputRef.current?.focus()
+    },
+    search(value: string) {
+      setDisableSuggest(true)
+      setQ(value)
+      setOpen(false)
+      setSuggestions([])
+      setHighlight(-1)
+      handleSubmit(value)
     },
   }))
 


### PR DESCRIPTION
## Summary
- expose `search` method on SearchBar to allow programmatic submission
- execute search immediately when choosing a smart suggestion

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7c6b4e77c832f92a8859b67d3ee9b