### PR TITLE
Update search prompt placeholder text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -63,10 +63,6 @@ export default function Page() {
 
         <SmartSuggestions onSelect={(country) => searchRef.current?.search(country)} />
 
-        <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-400">
-          Type a <em>country</em> or <em>city</em>.
-        </p>
-
       <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (
           <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700 dark:border-red-900 dark:bg-red-900/20 dark:text-red-300">

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -125,7 +125,7 @@ export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => 
             setQ(e.target.value)
           }}
           onKeyDown={onKeyDown}
-          placeholder="I’m going to…"
+          placeholder="Type a country or city"
           autoComplete="off"
           className="h-14 w-full rounded-full bg-transparent text-base outline-none placeholder:text-neutral-400 dark:text-neutral-100 dark:placeholder:text-neutral-500"
           aria-autocomplete="list"


### PR DESCRIPTION
## Summary
- update search bar placeholder to "Type a country or city"
- remove redundant hint below smart suggestions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a7c9a25218832fb84224d154d34013