### PR TITLE
feat: allow hiding smart suggestions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,9 +27,10 @@ export default function Page() {
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
   const [error, setError] = useState<string | null>(null)
   const [results, setResults] = useState<LookupOk[]>([])
+  const [showSuggestions, setShowSuggestions] = useState(true)
   const searchRef = useRef<SearchBarHandle>(null)
 
-  async function onSubmit(q: string) {
+  async function onSubmit(q: string, fromSuggestion?: boolean) {
     if (!q.trim()) return
     setError(null)
     setState('loading')
@@ -47,6 +48,7 @@ export default function Page() {
       setResults((prev) => [data, ...prev])
       setState('done')
       setTimeout(() => setState('idle'), 800)
+      if (!fromSuggestion) setShowSuggestions(false)
     } catch (e) {
       setError('Something went wrong. Please try again.')
       setState('idle')
@@ -61,7 +63,19 @@ export default function Page() {
 
         <SearchBar ref={searchRef} onSubmit={onSubmit} />
 
-        <SmartSuggestions onSelect={(country) => searchRef.current?.search(country)} />
+        {showSuggestions ? (
+          <SmartSuggestions
+            onSelect={(country) => searchRef.current?.search(country)}
+            onHide={() => setShowSuggestions(false)}
+          />
+        ) : (
+          <button
+            onClick={() => setShowSuggestions(true)}
+            className="mt-6 text-xs text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+          >
+            Show smart suggestions
+          </button>
+        )}
 
       <div className="mt-8 w-full space-y-4" aria-live="polite">
         {error && (

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -14,8 +14,10 @@ export type SearchBarHandle = {
   search: (v: string) => void
 }
 
-export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => void }>(
-  function SearchBar({ onSubmit }, ref) {
+export const SearchBar = forwardRef<
+  SearchBarHandle,
+  { onSubmit: (q: string, fromSuggestion?: boolean) => void }
+>(function SearchBar({ onSubmit }, ref) {
   const [q, setQ] = useState('')
   const [state, setState] = useState<'idle' | 'loading' | 'done'>('idle')
   const [suggestions, setSuggestions] = useState<Suggestion[]>([])
@@ -41,7 +43,7 @@ export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => 
       setOpen(false)
       setSuggestions([])
       setHighlight(-1)
-      handleSubmit(value)
+      handleSubmit(value, true)
     },
   }))
 
@@ -69,11 +71,11 @@ export const SearchBar = forwardRef<SearchBarHandle, { onSubmit: (q: string) => 
     return () => clearTimeout(t)
   }, [q, disableSuggest])
 
-  function handleSubmit(value: string) {
+  function handleSubmit(value: string, fromSuggestion = false) {
     if (!value.trim()) return
     inputRef.current?.blur()
     setState('loading')
-    onSubmit(value)
+    onSubmit(value, fromSuggestion)
     // state will be flipped to done by parent via props? We keep local animation:
     setTimeout(() => setState('done'), 600)
     setTimeout(() => setState('idle'), 1200)

--- a/components/SmartSuggestions.tsx
+++ b/components/SmartSuggestions.tsx
@@ -58,9 +58,10 @@ const SUGGESTIONS = RECOMMENDED.map(({ city, country }) => {
 
 type Props = {
   onSelect: (country: string) => void
+  onHide?: () => void
 }
 
-export function SmartSuggestions({ onSelect }: Props) {
+export function SmartSuggestions({ onSelect, onHide }: Props) {
   const origin = ORIGIN
   const scrollRef = useRef<HTMLDivElement>(null)
   const [canScrollLeft, setCanScrollLeft] = useState(false)
@@ -85,6 +86,15 @@ export function SmartSuggestions({ onSelect }: Props) {
     <div className="mt-6 w-full">
       <div className="mb-2 flex items-center justify-between text-xs text-neutral-500 dark:text-neutral-400">
         <span>Smart suggestions (from {origin.name})</span>
+        {onHide && (
+          <button
+            type="button"
+            onClick={onHide}
+            className="text-neutral-500 underline hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200"
+          >
+            Hide
+          </button>
+        )}
       </div>
       <div className="relative">
         <div


### PR DESCRIPTION
## Summary
- add UI to hide smart suggestions
- hide smart suggestions automatically after manual queries

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a7d0e48218832fa471f39d5693e5fe