### PR TITLE
Simplify plug question title

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -66,8 +66,8 @@ export default function Page() {
 
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center px-4 py-12 sm:py-16 md:min-h-screen md:py-0 md:justify-center">
-      <h1 className="mb-8 flex flex-nowrap items-baseline justify-center overflow-hidden text-center text-2xl font-extrabold tracking-tight sm:text-3xl md:text-4xl">
-        <span className="flex-none">What plug type do I need for</span>
+      <h1 className="mb-8 flex flex-wrap items-baseline justify-center text-center text-xl font-extrabold tracking-tight sm:text-2xl md:text-3xl">
+        <span className="flex-none">What plug do I need for</span>
         <span className="ml-1 min-w-0">
           <AnimatePresence mode="wait" initial={false}>
             <motion.span
@@ -76,7 +76,7 @@ export default function Page() {
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -4 }}
               transition={{ duration: 0.2 }}
-              className="block truncate underline"
+              className="block underline"
             >
               {locations[titleIndex]}
             </motion.span>


### PR DESCRIPTION
## Summary
- Remove the word "type" from the animated title and allow wrapping so long country names are fully visible
- Reduce heading font sizes to prevent overflow and drop location text truncation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7d710952c832f8d0810ecf049088c