### PR TITLE
feat: use Satoshi font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <head>
+        <link
+          href="https://fonts.cdnfonts.com/css/satoshi"
+          rel="stylesheet"
+        />
         <Script id="theme-script" strategy="beforeInteractive">
           {`
             (() => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,11 @@ export default {
     './components/**/*.{ts,tsx}'
   ],
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        sans: ['Satoshi', 'sans-serif']
+      }
+    }
   },
   plugins: []
 } satisfies Config


### PR DESCRIPTION
## Summary
- load Satoshi font in layout head
- configure Tailwind to use Satoshi as default sans font

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68a7d83562b4832f83d9786eb3079fc5